### PR TITLE
CompletedList 관련 로직변경

### DIFF
--- a/src/components/calendar/myCalendarTodoList.jsx
+++ b/src/components/calendar/myCalendarTodoList.jsx
@@ -17,6 +17,7 @@ const MyCalendarTodoList = ({ todoItems, onCompletedEvent }) => {
                 }
             })
         })
+        arr.sort((a, b) => a.startDate.localeCompare(b.startDate))
         return arr
     }
 
@@ -29,6 +30,7 @@ const MyCalendarTodoList = ({ todoItems, onCompletedEvent }) => {
                 }
             })
         })
+        arr.sort((a, b) => a.startDate.localeCompare(b.startDate))
         return arr
     }
 

--- a/src/type/dateType.js
+++ b/src/type/dateType.js
@@ -1,3 +1,4 @@
+import moment from "moment"
 import DateUtil from "../util/dateUtil"
 import ErrorUtil from "../util/errorUtil"
 
@@ -65,11 +66,16 @@ DateType.castToMonth = function(month) {
     return changedMonth
 }
 
+//prev => startDate of calendar, next => endDate of calendar
+//all props should be same month range
 DateType.isBetween = function(now, prev, next) {
     ErrorUtil.typeCheck(now, "string")
     ErrorUtil.typeCheck(prev, "string")
     ErrorUtil.typeCheck(next, "string")
-    const between =  DateUtil.isBetween(now, prev, next)
+    const startDay = moment().startOf("month").format("YYYY-MM-DD")
+    const endDay = moment().endOf("month").format("YYYY-MM-DD")
+    if(!DateUtil.isBetween(prev, startDay, endDay) || !DateUtil.isBetween(next, startDay, endDay)) return false
+    const between =  DateUtil.isBetween(now, startDay, endDay)
     return between
 }
 

--- a/src/type/dateType.js
+++ b/src/type/dateType.js
@@ -1,4 +1,3 @@
-import moment from "moment"
 import DateUtil from "../util/dateUtil"
 import ErrorUtil from "../util/errorUtil"
 
@@ -72,10 +71,10 @@ DateType.isBetween = function(now, prev, next) {
     ErrorUtil.typeCheck(now, "string")
     ErrorUtil.typeCheck(prev, "string")
     ErrorUtil.typeCheck(next, "string")
-    const startDay = moment().startOf("month").format("YYYY-MM-DD")
-    const endDay = moment().endOf("month").format("YYYY-MM-DD")
-    if(!DateUtil.isBetween(prev, startDay, endDay) || !DateUtil.isBetween(next, startDay, endDay)) return false
-    const between =  DateUtil.isBetween(now, startDay, endDay)
+    const month = DateUtil.dateFromMonth()
+    
+    if(!DateUtil.isBetween(prev, month[0], month[1]) || !DateUtil.isBetween(next, month[0], month[1])) return false
+    const between =  DateUtil.isBetween(now, month[0], month[1])
     return between
 }
 

--- a/src/util/dateUtil.js
+++ b/src/util/dateUtil.js
@@ -69,6 +69,14 @@ DateUtil.isBetween = function(now, prev, next) {
     return moment(now).isBetween(prev, next, undefined, "[]")
 }
 
+DateUtil.dateFromMonth = function() {
+    const month = []
+    const startDay = moment().startOf("month").format("YYYY-MM-DD")
+    const endDay = moment().endOf("month").format("YYYY-MM-DD")
+    month.push(startDay, endDay)
+    return month
+}
+
 DateUtil.castToDay = function(day) {
     switch(day) {
         case "Mon":

--- a/src/util/dateUtil.js
+++ b/src/util/dateUtil.js
@@ -66,8 +66,7 @@ DateUtil.isSame = function(current, compare) {
 }
 
 DateUtil.isBetween = function(now, prev, next) {
-    
-    return moment(now).isBetween(DateUtil.dateCalculate(prev, 1, "subtract", "days"), moment(next))
+    return moment(now).isBetween(prev, next, undefined, "[]")
 }
 
 DateUtil.castToDay = function(day) {


### PR DESCRIPTION
MyCalendarCompleteList
startDate로 정렬추가

DateType
리스트 범위 정립
같은 달 내의 일정만 반환

DateUtil
isBetween => now가 같은 날을 포함하도록 변경

dateFromMonth (신규)
태평양표준시 대한민국 기준
이번달의 시작날짜와 끝날짜를 반환 => isBetween에서 Range를 이번달로 고정하기 위함